### PR TITLE
Support for module:content 

### DIFF
--- a/examples/htmlWhiskers.hs
+++ b/examples/htmlWhiskers.hs
@@ -1,0 +1,28 @@
+module Main where
+
+import Text.RSS
+
+import Data.Maybe
+import Network.URI
+import System.IO.Unsafe
+import Data.Time.Clock
+
+main = putStrLn . showXML . rssToXML . rss =<< getCurrentTime
+
+rss :: UTCTime -> RSS
+rss t = RSS "my whiskers"
+            (fromJust (parseURI "http://www.n-heptane.com"))
+            "they are very pointy and luxurious"
+            []
+            [[ Title "yea-haw"
+             , Link (fromJust (parseURI "http://www.n-heptane.com/"))
+             , Description "the best site ever!!!"
+             , ContentEncoded "the <b>best</b> site ever!!!"
+             , Author "jeremy@n-heptane.com (Jeremy Shaw)"
+             , Category Nothing "meow"
+             , Enclosure (fromJust (parseURI "http://www.n-heptane.com/newpics/alice.gif")) 7333 "image/jpeg"
+             , Guid True "whee babayyyy!"
+             , PubDate t
+             , Source (fromJust (parseURI "http://www.google.com/")) "The best search engine eva!"
+             ]
+            ]

--- a/rss.cabal
+++ b/rss.cabal
@@ -1,5 +1,5 @@
 Name: rss
-Version: 3000.2.0.2
+Version: 3000.2.1.0
 Cabal-version: >=1.6
 Build-type: Simple
 Copyright: Jeremy Shaw 2004, Bjorn Bringert 2004-2006


### PR DESCRIPTION
I added support for content:encoded that is pretty widely used to integrate HTML content in RSS feeds.

I'm currently using it in LearnByHacking. See for example https://www.learnbyhacking.org/posts
and the corresponding code: https://github.com/scslab/lbh

I can add support for ther other stuff mentioned in the module (e.g., content:item), but I don't think they're as widely used as content encoded.

[Sorry for bumping the version, I can drop it if you wish]
