### PR TITLE
Remove redundant/restrictive time dependency

### DIFF
--- a/rss.cabal
+++ b/rss.cabal
@@ -31,7 +31,6 @@ flag network-uri
 Library
   build-depends: base       >= 3      && < 5
                , HaXml      >= 1.24
-               , time       >= 1.1.2  && < 1.5
                , old-locale >= 1.0    && < 1.1
 
   if flag(old-locale)


### PR DESCRIPTION
I believe the extra dependency is present in error. With it, we always end up with `time < 1.5`, whereas we really want to allow 1.5.*.