### PR TITLE
Bump time upper bound to (< 1.7)

### DIFF
--- a/rss.cabal
+++ b/rss.cabal
@@ -37,7 +37,7 @@ Library
     build-depends: time       >= 1.1.2 && < 1.5
                  , old-locale >= 1.0   && < 1.1
   else
-    build-depends: time >= 1.5 && < 1.6
+    build-depends: time >= 1.5 && < 1.7
 
   if flag(network-uri)
     build-depends: network-uri >= 2.6 && < 2.7


### PR DESCRIPTION
Tested by running `main` from `examples/whiskers.hs` in a repl<sup>*</sup> :

```
<rss version="2.0">
  <channel>
    <title>my whiskers</title>
    <link>http://www.n-heptane.com</link>
    <description>they are very pointy and luxurious</description>
    <docs>http://www.rssboard.org/rss-specification</docs>
    <item>
      <title>yea-haw</title>
      <link>http://www.n-heptane.com/</link>
      <description>the best site ever!!!</description>
      <author>jeremy@n-heptane.com (Jeremy Shaw)</author>
      <category>meow</category>
      <enclosure url="http://www.n-heptane.com/newpics/alice.gif" length="7333" type="image/jpeg"/>
      <guid isPermaLink="true">whee babayyyy!</guid>
      <pubDate>Wed, 26 Oct 2016 00:09:48 UTC</pubDate>
      <source url="http://www.google.com/">The best search engine eva!</source>
    </item>
  </channel>
</rss>
```

Haha :)

<sup>*</sup> Intented by hand
