### PR TITLE
raise time bound to < 1.9

### DIFF
--- a/rss.cabal
+++ b/rss.cabal
@@ -37,7 +37,7 @@ Library
     build-depends: time       >= 1.1.2 && < 1.5
                  , old-locale >= 1.0   && < 1.1
   else
-    build-depends: time >= 1.5 && < 1.7
+    build-depends: time >= 1.5 && < 1.9
 
   if flag(network-uri)
     build-depends: network-uri >= 2.6 && < 2.7


### PR DESCRIPTION
I tested this package with Stackage nightly-2018-02-27, which uses `time-1.8.0.2`, and it seems to work. So I'm proposing raising the bound to include `time-1.8.x` and close #8.
